### PR TITLE
Add Arch tag for OC patches

### DIFF
--- a/opencore.config.plist
+++ b/opencore.config.plist
@@ -7,6 +7,8 @@
 		<key>Patch</key>
 		<array>
 			<dict>
+				<key>Arch</key>
+				<string>Any</string>
 				<key>Base</key>
 				<string></string>
 				<key>Comment</key>
@@ -35,6 +37,8 @@
 				<integer>0</integer>
 			</dict>
 			<dict>
+				<key>Arch</key>
+				<string>Any</string>
 				<key>Base</key>
 				<string></string>
 				<key>Comment</key>


### PR DESCRIPTION
[Per OC docs](https://github.com/acidanthera/OpenCorePkg/blob/b34c2ddfda2c712fcc0517e9d976a2b3d683edd7/Docs/Configuration.tex#L2338), at @82ghost82's [suggestion](https://forums.unraid.net/topic/84430-hackintosh-tips-to-make-a-bare-metal-macos/?do=findComment&comment=1047775).