### PR TITLE
Fix patches and readme

### DIFF
--- a/clover.config.BigSur.Monterey.plist
+++ b/clover.config.BigSur.Monterey.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KernelAndKextPatches</key>
+	<dict>
+		<key>KernelToPatch</key>
+		<array>
+			<dict>
+				<key>Comment</key>
+				<string>Block sysctl machdep.cpu.features VMM flag</string>
+				<key>Disabled</key>
+				<false/>
+				<key>Find</key>
+				<data>AFZNTQA=</data>
+				<key>Replace</key>
+				<data>AFhYWAA=</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Block sysctl kern.hv_vmm_present call</string>
+				<key>Disabled</key>
+				<false/>
+				<key>Find</key>
+				<data>aHZfdm1tX3ByZXNlbnQ=</data>
+				<key>Replace</key>
+				<data>aHZfeHh4X3ByZXNlbnQ=</data>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/clover.config.HighSierra.Mojave.Catalina.plist
+++ b/clover.config.HighSierra.Mojave.Catalina.plist
@@ -16,16 +16,6 @@
 				<key>Replace</key>
 				<data>AFhYWAA=</data>
 			</dict>
-			<dict>
-				<key>Comment</key>
-				<string>Block sysctl kern.hv_vmm_present call</string>
-				<key>Disabled</key>
-				<false/>
-				<key>Find</key>
-				<data>aHZfdm1tX3ByZXNlbnQ=</data>
-				<key>Replace</key>
-				<data>aHZfeHh4X3ByZXNlbnQ=</data>
-			</dict>
 		</array>
 	</dict>
 </dict>

--- a/opencore.config.plist
+++ b/opencore.config.plist
@@ -58,7 +58,7 @@
 				<key>MaxKernel</key>
 				<string>21.99.99</string>
 				<key>MinKernel</key>
-				<string>17.0.0</string>
+				<string>20.4.0</string>
 				<key>Replace</key>
 				<data>aHZfeHh4X3ByZXNlbnQ=</data>
 				<key>ReplaceMask</key>


### PR DESCRIPTION
Hi, sorry not an expert with prs in github, I hope all is done well.
Changes:
Readme:
Added preferred e1000-82545em/virtio/virtio-net instead of vmxnet3

Replace clover.config.plist with clover.config.HighSierra.Mojave.Catalina and clover.config.BigSur.Monterey.plist:
HighSierra/Mojave/Catalina require only VMM->XXX patch, Big Sur and Monterey require additional hv_vmm_present->hv_xxx_present patch
As far as I know clover doesn't have any "minkernel" option.

Updated opencore.config.plist minkernel to 20.4.0 for hv_vmm_present->hv_xxx_present: 20.4.0 is Big Sur 11.3, is it correct, right?

Feel free to comment, merge, modify or reject.

Thank you